### PR TITLE
Use jsDelivr as a CDN

### DIFF
--- a/docs/markdown/en/installation.md
+++ b/docs/markdown/en/installation.md
@@ -16,15 +16,15 @@ npm install at-ui-style
 
 Can use traditional `<script>` and `<link>` tag for global use.
 
-Get the latest version of `AT-UI` from [UNPKG](https://unpkg.com/at-ui/).
+Get the latest version of `AT-UI` from [jsDelivr](https://www.jsdelivr.com/package/npm/at-ui).
 
 ```html
 <!-- import Vue -->
-<script src="//vuejs.org/js/vue.min.js"></script>
+<script src="//cdn.jsdelivr.net/npm/vue/dist/vue.min.js"></script>
 <!-- import CSS -->
-<link rel="stylesheet" href="//unpkg.com/at-ui-style/css/at.min.css">
+<link rel="stylesheet" href="//cdn.jsdelivr.net/npm/at-ui-style/css/at.min.css">
 <!-- import JavaScript -->
-<script src="//unpkg.com/at-ui/dist/at.min.js"></script>
+<script src="//cdn.jsdelivr.net/npm/at-ui/dist/at.min.js"></script>
 ```
 
 #### DEMO：
@@ -38,9 +38,9 @@ By using the script tag to import resources, we can quickly write a demo page wi
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
   <title>AT-UI Example</title>
-  <link rel="stylesheet" href="//unpkg.com/at-ui-style/css/at.min.css">
-  <script src="//vuejs.org/js/vue.min.js"></script>
-  <script src="//unpkg.com/at-ui/dist/at.min.js"></script>
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/at-ui-style/css/at.min.css">
+  <script src="//cdn.jsdelivr.net/npm/vue/dist/vue.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/at-ui/dist/at.min.js"></script>
   <style>
     #app {
       display: flex;

--- a/docs/markdown/zh/installation.md
+++ b/docs/markdown/zh/installation.md
@@ -16,15 +16,15 @@ npm install at-ui-style
 
 可以采用传统的 `<script>` 和 `<link>` 标签的方式引入资源，并且全局使用 `AT-UI`。
 
-可以在 [UNPKG](https://unpkg.com/at-ui/) 上找到最新版本的资源文件，然后在页面中直接引入
+可以在 [jsDelivr](https://www.jsdelivr.com/package/npm/at-ui) 上找到最新版本的资源文件，然后在页面中直接引入
 
 ```html
 <!-- 引入Vue -->
-<script src="//vuejs.org/js/vue.min.js"></script>
+<script src="//cdn.jsdelivr.net/npm/vue/dist/vue.min.js"></script>
 <!-- 引入样式 -->
-<link rel="stylesheet" href="//unpkg.com/at-ui-style/css/at.min.css">
+<link rel="stylesheet" href="//cdn.jsdelivr.net/npm/at-ui-style/css/at.min.css">
 <!-- 引入组件库 -->
-<script src="//unpkg.com/at-ui/dist/at.min.js"></script>
+<script src="//cdn.jsdelivr.net/npm/at-ui/dist/at.min.js"></script>
 ```
 
 #### 示例：
@@ -38,9 +38,9 @@ npm install at-ui-style
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
   <title>AT-UI Example</title>
-  <link rel="stylesheet" href="//unpkg.com/at-ui-style/css/at.min.css">
-  <script src="//vuejs.org/js/vue.min.js"></script>
-  <script src="//unpkg.com/at-ui/dist/at.min.js"></script>
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/at-ui-style/css/at.min.css">
+  <script src="//cdn.jsdelivr.net/npm/vue/dist/vue.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/at-ui/dist/at.min.js"></script>
   <style>
     #app {
       display: flex;


### PR DESCRIPTION
I replaced the CDN to jsDelivr for all links. jsDelivr is the fastest opensource CDN available and built specifically for production usage, and it is the only public CDN with servers in China.