### PR TITLE
Fix Table when changed.

### DIFF
--- a/src/components/table/src/table.vue
+++ b/src/components/table/src/table.vue
@@ -446,7 +446,13 @@ export default {
         const columnsWidth = {}
 
         if (this.data.length) {
-          const $td = this.$refs.body.querySelectorAll('tr')[0].querySelectorAll('td')
+          const $trs = this.$refs.body.querySelectorAll('tr')
+          
+          if ($trs.length === 0) {
+            return 
+          }
+          
+          const $td = $trs.querySelectorAll('td')
 
           for (let i = 0; i < $td.length; i++) {
             const column = this.columnsData[i]


### PR DESCRIPTION
Before unmount AtTable, sometimes this.$refs.body.querySelectorAll('tr') has not any element.
It is insecure.