### PR TITLE
使用过程中rate在disabled情况下,整数会渲染成半星。

### DIFF
--- a/src/components/rate/src/rate.vue
+++ b/src/components/rate/src/rate.vue
@@ -113,7 +113,7 @@ export default {
       const STAR_OFF_CLASS_NAME = 'at-rate__item--off'
       const STAR_HALF_CLASS_NAME = 'at-rate__item--half'
 
-      const isHalf = this.isHalf
+      const isHalf = this.disabled ? (this.value > Math.floor(this.value)) : this.isHalf
       const isHoverStar = this.hoverIndex !== -1
       const currentIndex = isHoverStar ? this.hoverIndex : this.currentValue
       const lastItemIndex = Math.ceil(currentIndex)


### PR DESCRIPTION
您好，at-ui很小巧，我使用了她作为一个小项目的ui框架。
使用过程中，rate组件在disable属性为true时，整数会渲染成半星。
比如10分会渲染成4.5星。

根据逻辑，如果直接判断值是否为半星，在disable=false的情况下，页面不能选择半星：
const isHalf = this.value > Math.floor(this.value)
所以在这个情况下，我做了判断，在disable的情况时，在方法局部判断是否为半星：
      const isHalf = this.disabled ? (this.value > Math.floor(this.value)) : this.isHalf

